### PR TITLE
fix: rna and protein filter use an out of range to disable it

### DIFF
--- a/app/common/elasticsearchclient.py
+++ b/app/common/elasticsearchclient.py
@@ -36,8 +36,9 @@ KEYWORD_MAPPING_FIELDS = ["name",
 
 
 def ex_level_meet_conditions(x, y, min_level, max_level):
-    '''meet conditions for a numerical range with y > x y upper bound
-    and x lower bound as max_level and min_level respectively'''
+    '''meet conditions for a numerical range with y > x y upper bound and x lower
+    bound as max_level and min_level respectively
+    '''
     diff = y - x
     return True if \
         min_level <= diff < max_level and \
@@ -46,9 +47,9 @@ def ex_level_meet_conditions(x, y, min_level, max_level):
 
 
 def ex_level_tissues_to_terms_list(key, ts, expression_level):
-    '''returns a list with a match dict per el in `ts` using the
-    private facet and `epxression_level` based on the `key` as a
-    str "protein" or "rna"'''
+    '''returns a list with a match dict per el in `ts` using the private facet and
+    `epxression_level` based on the `key` as a str "protein" or "rna"
+    '''
     return [
         {'match': {
             'private.facets.expression_tissues.' + key + '.' +
@@ -2095,11 +2096,11 @@ class SearchParams():
         self.filters[FilterTypes.DISEASE] = kwargs.get(FilterTypes.DISEASE)
         self.filters[FilterTypes.THERAPEUTIC_AREA] = kwargs.get(FilterTypes.THERAPEUTIC_AREA)
         self.filters[FilterTypes.RNA_EXPRESSION_LEVEL] = \
-            kwargs.get(FilterTypes.RNA_EXPRESSION_LEVEL, 1)
+            kwargs.get(FilterTypes.RNA_EXPRESSION_LEVEL, 0)
         self.filters[FilterTypes.RNA_EXPRESSION_TISSUE] = \
             kwargs.get(FilterTypes.RNA_EXPRESSION_TISSUE, [])
         self.filters[FilterTypes.PROTEIN_EXPRESSION_LEVEL] = \
-            kwargs.get(FilterTypes.PROTEIN_EXPRESSION_LEVEL, 1)
+            kwargs.get(FilterTypes.PROTEIN_EXPRESSION_LEVEL, 0)
         self.filters[FilterTypes.PROTEIN_EXPRESSION_TISSUE] = \
             kwargs.get(FilterTypes.PROTEIN_EXPRESSION_TISSUE, [])
         score_range = [0., self._max_score]
@@ -2143,13 +2144,13 @@ class SearchParams():
         self.eco = kwargs.get('eco', []) or []
 
         setattr(self, FilterTypes.RNA_EXPRESSION_LEVEL,
-                kwargs.get(FilterTypes.RNA_EXPRESSION_LEVEL, 1))
+                kwargs.get(FilterTypes.RNA_EXPRESSION_LEVEL, 0))
 
         setattr(self, FilterTypes.RNA_EXPRESSION_TISSUE,
                 kwargs.get(FilterTypes.RNA_EXPRESSION_TISSUE, []))
 
         setattr(self, FilterTypes.PROTEIN_EXPRESSION_LEVEL,
-                kwargs.get(FilterTypes.PROTEIN_EXPRESSION_LEVEL, 1))
+                kwargs.get(FilterTypes.PROTEIN_EXPRESSION_LEVEL, 0))
 
         setattr(self, FilterTypes.PROTEIN_EXPRESSION_TISSUE,
                 kwargs.get(FilterTypes.PROTEIN_EXPRESSION_TISSUE, []))
@@ -2734,7 +2735,7 @@ class AggregationUnitRNAExLevel(AggregationUnit):
                     }
                 }
             }
-        }
+        } if ex_level > 0 else {}
 
 
 class AggregationUnitRNAExTissue(AggregationUnit):
@@ -2807,7 +2808,7 @@ class AggregationUnitRNAExTissue(AggregationUnit):
                     }
                 }
             }
-        }
+        } if ex_level > 0 else {}
 
 
 class AggregationUnitPROExLevel(AggregationUnit):
@@ -2883,7 +2884,7 @@ class AggregationUnitPROExLevel(AggregationUnit):
                     }
                 }
             }
-        }
+        } if ex_level > 0 else {}
 
 
 class AggregationUnitPROExTissue(AggregationUnit):
@@ -2956,7 +2957,7 @@ class AggregationUnitPROExTissue(AggregationUnit):
                     }
                 }
             }
-        }
+        } if ex_level > 0 else {}
 
 
 class AggregationUnitScoreRange(AggregationUnit):
@@ -3153,10 +3154,10 @@ class AggregationBuilder(object):
         FilterTypes.THERAPEUTIC_AREA: AggregationUnitTherapeuticArea,
         FilterTypes.GO: AggregationUnitGO,
         FilterTypes.TARGET_CLASS: AggregationUnitTargetClass,
-        # FilterTypes.RNA_EXPRESSION_LEVEL: AggregationUnitRNAExLevel,
-        # FilterTypes.RNA_EXPRESSION_TISSUE: AggregationUnitRNAExTissue,
-        # FilterTypes.PROTEIN_EXPRESSION_LEVEL: AggregationUnitPROExLevel,
-        # FilterTypes.PROTEIN_EXPRESSION_TISSUE: AggregationUnitPROExTissue
+        FilterTypes.RNA_EXPRESSION_LEVEL: AggregationUnitRNAExLevel,
+        FilterTypes.RNA_EXPRESSION_TISSUE: AggregationUnitRNAExTissue,
+        FilterTypes.PROTEIN_EXPRESSION_LEVEL: AggregationUnitPROExLevel,
+        FilterTypes.PROTEIN_EXPRESSION_TISSUE: AggregationUnitPROExTissue
     }
 
     _SERVICE_FILTER_TYPES = [FilterTypes.IS_DIRECT,

--- a/app/resources/association.py
+++ b/app/resources/association.py
@@ -63,12 +63,12 @@ class FilterBy(restful.Resource):
         parser.add_argument('pathway', type=str, action='append', required=False, )
         parser.add_argument(FilterTypes.TARGET_CLASS, type=int, action='append', )
         parser.add_argument('uniprotkw', type=str, action='append', required=False,)
-        parser.add_argument('rna_expression_level', type=int, default=1,
-                            choices=list(xrange(1, 11)), required=False)
+        parser.add_argument('rna_expression_level', type=int, default=0,
+                            choices=list(xrange(0, 11)), required=False)
         parser.add_argument('rna_expression_tissue', type=str, action='append',
                             required=False)
-        parser.add_argument('protein_expression_level', type=int, default=1,
-                            choices=list(xrange(1, 4)), required=False)
+        parser.add_argument('protein_expression_level', type=int, default=0,
+                            choices=list(xrange(0, 4)), required=False)
         parser.add_argument('protein_expression_tissue', type=str, action='append',
                             required=False)
         parser.add_argument('go', type=str, action='append', required=False,


### PR DESCRIPTION
if you set the level to 0 the filter will be removed and the search will return
as usual

reference #70 

this situation with the the association index gives a problem with tests. That index must have valid rna and protein expression levels included to pass the tests.

By default, the value is 0 for rna and protein expression level so if 0 the filter and aggs returned are empty so default results must appear there as usual.