### PR TITLE
return custom headers even for errors

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -312,7 +312,7 @@ def create_app(config_name):
             return resp
 
         except Exception as e:
-            app.logger.traceback('failed request teardown function', str(e))
+            app.logger.exception('failed request teardown function', str(e))
             return resp
 
     return app

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -330,6 +330,7 @@ def create_app(config_name):
 
     # Override the HTTP exception handler.
     app.handle_http_exception = get_http_exception_handler(app)
+    return app
 
 
 if __name__ == '__main__':

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -26,10 +26,13 @@ class RateLimitTestCase(GenericTestCase):
                                          rate_limit_fail=True,
                                          token = token)
             status_code = response.status_code
-            #check custom headers are present in both 200 and 429 responsese
-            self.assertIn('Access-Control-Allow-Origin', response.headers)
             if status_code == 429:
+                # check custom headers are present in error
+                self.assertIn('Access-Control-Allow-Origin', response.headers)
                 break
+            elif status_code == 200:
+                # check custom headers are present in correct responses
+                self.assertIn('Access-Control-Allow-Origin', response.headers)
 
         self.assertTrue(response.status_code == 429)
         # self.assertEqual(len(json_response['token'].split('.')), 3, 'token is in JWT format')

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -27,7 +27,7 @@ class RateLimitTestCase(GenericTestCase):
                                          token = token)
             status_code = response.status_code
             #check custom headers are present in both 200 and 429 responsese
-            self.assertIn('Access-Control-Allow-Origin', response['headers'])
+            self.assertIn('Access-Control-Allow-Origin', response.headers)
             if status_code == 429:
                 break
 

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -26,6 +26,8 @@ class RateLimitTestCase(GenericTestCase):
                                          rate_limit_fail=True,
                                          token = token)
             status_code = response.status_code
+            #check custom headers are present in both 200 and 429 responsese
+            self.assertIn('Access-Control-Allow-Origin', response['headers'])
             if status_code == 429:
                 break
 


### PR DESCRIPTION
moved from after_request to teardown_request to execute the function even when unhandled errors occurs