### PR TITLE
add back the swagger-ui functionality at /vX/platform/docs/swagger-ui

### DIFF
--- a/.circleci/runscope.py
+++ b/.circleci/runscope.py
@@ -19,9 +19,9 @@ def base_path():
     return '/v{}/platform'.format(os.environ['API_VERSION'])
 
 def ping():
-    return requests.get('https://' + 
-                            host_url() + 
-                            base_path() + 
+    return requests.get('https://' +
+                            host_url() +
+                            base_path() +
                             '/public/utils/ping')
 
 TRIGGER_URL = "https://api.runscope.com/radar/bucket/{}/trigger".format(os.environ['RUNSCOPE_BUCKET_ID'])
@@ -42,12 +42,12 @@ def main():
     while ping().status_code != 200:
         sys.stdout.write('.')
         sys.stdout.flush()
-        time.sleep(attempts)
+        time.sleep(attempts ** 2)
         attempts+=1
-        if attempts > 10: raise SystemExit('no API available')
+        if attempts > 8: raise SystemExit('no API available')
 
 
-    print 'Triggering runscope tests'    
+    print 'Triggering runscope tests'
     trigger_resp = requests.get(TRIGGER_URL,params=PAYLOAD)
 
     if trigger_resp.ok:
@@ -85,7 +85,7 @@ def _get_result(test_run):
         sys.exit(1)
 
     API_TOKEN = os.environ["RUNSCOPE_ACCESS_TOKEN"]
-    
+
     opts = {
         "base_url": "https://api.runscope.com",
         "bucket_key": test_run.get("bucket_key"),

--- a/api-description.md
+++ b/api-description.md
@@ -6,9 +6,14 @@ allows programmatic retrieval of our data via a set of
 services.
 
 You can make calls to the latest version of our API using the base URL
- `https://api.opentargets.io/v3/platform`. Please make sure you use `https` instead of the unencrypted
- `http` calls, which we do not accept. Note that we only serve the latest version of the API. If you are interested in querying
- an old version, please [get in touch](mailto:support@targetvalidation.org) so that we can help.
+`https://api.opentargets.io/v3/platform`. Please make sure you use `https`
+instead of the unencrypted `http` calls, which we do not accept.
+
+Continue reading below or [try query in the interactive interface](https://api.opentargets.io/v3/platform/docs/swagger-ui)
+
+Note that we only serve the latest version of the API. If you are interested in querying an
+old version, please [get in touch](mailto:support@targetvalidation.org) so that
+we can help.
 
 We list below the methods available for you to query our data directly from the API. These methods will be
 automatically generated from our Swagger UI. For every request you create, the interface will display a [curl](https://curl.haxx.se/) command

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -246,7 +246,7 @@ def create_app(config_name):
 
 
     '''serve the static docs'''
-    
+
     try:
         '''
         NOTE: this file gets created only at deployment time
@@ -272,6 +272,9 @@ def create_app(config_name):
     def render_redoc(apiversion=api_version):
         return render_template('docs.html',api_version=apiversion)
 
+    @app.route('/v%s/platform/docs/swagger-ui' % str(api_version))
+    def render_swaggerui(apiversion=api_version):
+        return render_template('swaggerui.html',api_version=apiversion)
 
     '''pre and post-request'''
 

--- a/app/common/elasticsearchclient.py
+++ b/app/common/elasticsearchclient.py
@@ -1413,11 +1413,21 @@ class esQuery():
         keyword_operator = None
         keyword_analyzer = "keyword"
         keyword_type = "best_fields"
-        keyword_fields = ["id.keyword^100",
-                          "symbol.keyword^100",
-                          "approved_symbol.keyword^100",
-                          "uniprot_accessions.keyword^100",
-                          ]
+        # keyword_fields = ["id.keyword^100",
+        #                   "symbol.keyword^100",
+        #                   "approved_symbol.keyword^100",
+        #                   "uniprot_accessions.keyword^100",
+        #                   ]
+        keyword_fields = ["name.keyword^100",
+                          "id^100",
+                          "symbol^100",
+                          "approved_name.keyword^100",
+                          "approved_symbol^100",
+                          "symbol_synonyms^100",
+                          "name_synonyms^100",
+                          "uniprot_accessions^100",
+                          "hgnc_id^100",
+                          "ensembl_gene_id^100"]
 
         if params:
             if 'drug' in params.search_profile:

--- a/app/templates/docs.html
+++ b/app/templates/docs.html
@@ -18,6 +18,6 @@
   </head>
   <body>
     <redoc spec-url='/v{{ api_version }}/platform/swagger'></redoc>
-    <script src="https://rebilly.github.io/ReDoc/releases/v1.19.1/redoc.min.js"> </script>
+    <script src="https://rebilly.github.io/ReDoc/releases/latest/redoc.min.js"> </script>
   </body>
 </html>

--- a/app/templates/swaggerui.html
+++ b/app/templates/swaggerui.html
@@ -1,0 +1,62 @@
+<!-- HTML for static distribution bundle build -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Swagger UI</title>
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
+    <!-- <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.15.0/swagger-ui.css" > -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-themes@3.0.0/themes/3.x/theme-flattop.css" />
+    <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
+    <style>
+      html
+      {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+      }
+
+      *,
+      *:before,
+      *:after
+      {
+        box-sizing: inherit;
+      }
+
+      body
+      {
+        margin:0;
+        background: #fafafa;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="swagger-ui"></div>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.15.0/swagger-ui-bundle.js"> </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.15.0/swagger-ui-standalone-preset.js"> </script>
+    <script>
+    window.onload = function() {
+
+      // Build a system
+      const ui = SwaggerUIBundle({
+        url: "/v{{api_version}}/platform/swagger",
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl
+        ],
+        layout: "StandaloneLayout"
+      })
+
+      window.ui = ui
+    }
+  </script>
+  </body>
+</html>

--- a/openapi.template.yaml
+++ b/openapi.template.yaml
@@ -23,6 +23,15 @@ info:
     Fair usage is enforced with limits to the api calls. Consistently exceeding the fair usage limits will trigger at
     least a 24 hour ban.
 tags:
+  - name: filters
+    # open: true
+    description: Methods to filter the available evidence.
+  - name: retrieve
+    # open: true
+    description: Methods to get specific evidence.
+  - name: search
+    # open: true
+    description: Methods to search for target or diseases.
   - name: public
     # open: true
     description: Publicly supported stable API.
@@ -38,11 +47,16 @@ tags:
 x-tagGroups:
   - name: Stable
     tags:
-      - public
+      - filter
+      - retrieve
+      - search
   - name: Utilities
     tags:
-      - private
       - utils
+      - private
+  - name: All
+      - public
+      - private
 consumes:
   - application/json
 produces:
@@ -94,6 +108,7 @@ paths:
       operationId: getEvidenceById
       tags:
         - public
+        - retrieve
       description: |
         We call **evidence** a unit of data that support a connection between a target and a disease.
         The Open Targets Platform integrates multiple types of evidence including genetic associations,
@@ -131,6 +146,7 @@ paths:
       operationId: postEvidenceById
       tags:
         - public
+        - retrieve
       description: |
         This is the POST version of [/public/evidence](#!/public/get_public_evidence).
         It allows to query for a list of evidence strings encoded in a `json` object to be passed in the body.
@@ -164,6 +180,7 @@ paths:
       operationId: getEvidenceFilter
       tags:
         - public
+        - filter
       description: |
         The filter method allows to retrieve the specific data that supports a connection between targets and diseases.
         Filters can be used to restrict the results by source and type of data,
@@ -256,6 +273,7 @@ paths:
       operationId: postEvidenceFilter
       tags:
         - public
+        - filter
       description: |
         POST version of [/public/evidence/filter](#!/public/get_public_evidence_filter).
         Filters can be specified as part of a `json` object in the body, simplifying the submission of queries.
@@ -289,6 +307,7 @@ paths:
       operationId: getAssociationById
       tags:
         - public
+        - retrieve
       description: |
        Once we integrate all evidence connecting a target to a specific disease, we
         compute an association score by the means of an harmonic sum. This *association score* provides
@@ -313,6 +332,7 @@ paths:
       operationId: getAssociationFilter
       tags:
         - public
+        - filter
       description: |
         More complex queries for associations scores and objects can be done using
         this method, which allows to sort in different order, restrict to a specific class
@@ -449,6 +469,7 @@ paths:
       operationId: postAssociationFilter
       tags:
         - public
+        - filter
       description: |
         Complex queries and filters for association objects can also be submitted using a JSON
         object and the equivalent POST method.
@@ -477,8 +498,8 @@ paths:
           #       id:
           #         type: string
   /platform/private/disease/{disease}:
-    summary: Find information about a disease
     get:
+      summary: Find information about a disease
       operationId: getDiseaseById
       tags:
         - private
@@ -494,8 +515,8 @@ paths:
         200:
           description: Successful response
   /platform/private/disease:
-    summary: Find information about a list of diseases
     post:
+      summary: Find information about a list of diseases
       operationId: postDiseaseById
       tags:
         - private
@@ -710,6 +731,7 @@ paths:
       operationId: getSearch
       tags:
         - public
+        - search
       description: |
         This method allows you to look for gene or diseases of interest using a free text search,
         replicating the functionality of the search box on our homepage. It should be used to identify

--- a/openapi.template.yaml
+++ b/openapi.template.yaml
@@ -35,6 +35,14 @@ tags:
   - name: utils
     # open: true
     description: Utility methods.
+x-tagGroups:
+  - name: Stable
+    tags:
+      - public
+  - name: Utilities
+    tags:
+      - private
+      - utils
 consumes:
   - application/json
 produces:
@@ -46,6 +54,7 @@ produces:
 paths:
   /platform/swagger:
     get:
+      summary: Get OpenAPI schema
       operationId: getSwagger
       tags:
         - private
@@ -57,6 +66,7 @@ paths:
           description: "Swagger.yaml file"
   /platform/docs:
     get:
+      summary: Browse API documentation
       operationId: getApiDocs
       tags:
         - private
@@ -68,6 +78,7 @@ paths:
           description: "Redoc API documentation file"
   /platform/docs/swagger-ui:
     get:
+      summary: Browse interactive API documentation
       operationId: getApiSwaggerUI
       tags:
         - private
@@ -79,6 +90,7 @@ paths:
           description: "Swagger-UI API documentation file"
   /platform/public/evidence:
     get:
+      summary: Get evidence by ID
       operationId: getEvidenceById
       tags:
         - public
@@ -96,7 +108,7 @@ paths:
       parameters:
         - name: id
           in: query
-          description: ID of the evidence string to retrieve.
+          description: Internal unique ID of the evidence string to retrieve.
           required: true
           type: string
       responses:
@@ -115,6 +127,7 @@ paths:
           #       id:
           #         type: string
     post:
+      summary: Get evidence for a list of IDs
       operationId: postEvidenceById
       tags:
         - public
@@ -147,6 +160,7 @@ paths:
           #         type: string
   /platform/public/evidence/filter:
     get:
+      summary: Filter available evidence
       operationId: getEvidenceFilter
       tags:
         - public
@@ -238,6 +252,7 @@ paths:
         200:
           description: Successful response
     post:
+      summary: Batch filter available evidence
       operationId: postEvidenceFilter
       tags:
         - public
@@ -270,6 +285,7 @@ paths:
           #         type: string
   /platform/public/association:
     get:
+      summary: Get association by id
       operationId: getAssociationById
       tags:
         - public
@@ -293,6 +309,7 @@ paths:
           description: Successful response
   /platform/public/association/filter:
     get:
+      summary: Filter available associations
       operationId: getAssociationFilter
       tags:
         - public
@@ -428,6 +445,7 @@ paths:
           #       id:
           #         type: string
     post:
+      summary: Batch query available associations
       operationId: postAssociationFilter
       tags:
         - public
@@ -459,6 +477,7 @@ paths:
           #       id:
           #         type: string
   /platform/private/disease/{disease}:
+    summary: Find information about a disease
     get:
       operationId: getDiseaseById
       tags:
@@ -475,6 +494,7 @@ paths:
         200:
           description: Successful response
   /platform/private/disease:
+    summary: Find information about a list of diseases
     post:
       operationId: postDiseaseById
       tags:
@@ -496,6 +516,7 @@ paths:
           description: Successful response
   /platform/private/eco/{ECO_ID}:
     get:
+      summary: Get evidence code by ID
       operationId: getECObyID
       tags:
         - private
@@ -512,6 +533,7 @@ paths:
           description: Successful response
   /platform/private/target/{target}:
     get:
+      summary: Find information about a target
       operationId: getTargetByENSGID
       tags:
         - private
@@ -528,11 +550,12 @@ paths:
           description: Successful response
   /platform/private/target:
     post:
+      summary: Find information about a list of targets
       operationId: postTargetByENSGID
       tags:
         - private
       description: |
-         Get `target` objects.
+         Get `target` objects. Used for the target profile page.
       parameters:
         - name: body
           in: body
@@ -548,6 +571,7 @@ paths:
           description: Successful response
   /platform/private/target/expression:
     get:
+      summary: Query expression levels
       operationId: getTargetExpressionByENSGID
       tags:
         - private
@@ -563,6 +587,7 @@ paths:
         200:
           description: Successful response
     post:
+      summary: Batch query expression levels
       operationId: postTargetExpressionByENSGID
       tags:
         - private
@@ -582,6 +607,7 @@ paths:
           description: Successful response
   /platform/private/relation/target/{target}:
     get:
+      summary: Find related entities by target
       operationId: getRelationByENSGID
       tags:
         - private
@@ -598,6 +624,7 @@ paths:
           description: Successful response
   /platform/private/relation:
     post:
+      summary: Find related entities
       operationId: postRelation
       tags:
         - private
@@ -617,6 +644,7 @@ paths:
           description: Successful response
   /platform/private/relation/disease/{disease}:
     get:
+      summary: Find related entities by disease
       operationId: getRelationByEFOID
       tags:
         - private
@@ -633,6 +661,7 @@ paths:
           description: Successful response
   /platform/private/besthitsearch:
     post:
+      summary: Find the best hit
       operationId: postBestHitSearch
       tags:
         - private
@@ -655,6 +684,7 @@ paths:
           description: Successful response
   /platform/private/enrichment/targets:
     post:
+      summary: Enrichment analysis
       operationId: postEnrichmentTarget
       tags:
         - private
@@ -676,6 +706,7 @@ paths:
           description: Successful response
   /platform/public/search:
     get:
+      summary: Search for a disease or a target
       operationId: getSearch
       tags:
         - public
@@ -709,11 +740,12 @@ paths:
           description: Successful response
   /platform/private/quicksearch:
     get:
+      summary: Search most relevant results
       operationId: getQuickSearch
       tags:
         - private
       description: |
-        Get `search-result` objects.
+        Get `search-result` objects. Enables search bar functionality.
       parameters:
         - name: q
           in: query
@@ -730,11 +762,12 @@ paths:
           description: Successful response
   /platform/private/autocomplete:
     get:
+      summary: Get `autocomplete` objects.
       operationId: getAutocomplete
       tags:
         - private
       description: |
-        Get `autocomplete` objects.
+        Search for the closest term to autocomplete in the search box.
       parameters:
         - name: q
           in: query
@@ -801,34 +834,49 @@ paths:
           description: Successful response
   /platform/public/utils/ping:
     get:
+      summary: Ping service
       operationId: getPing
       tags:
         - public
         - utils
       description: |
-        Ping service
+        Check if the API is up
       responses:
         200:
           description: Successful response
   /platform/public/utils/version:
     get:
+      summary: Get API version
       operationId: getVersion
       tags:
         - public
         - utils
       description: |
-        Get current API version.
+        Returns current API version.
       responses:
         200:
           description: Successful response
+      x-code-samples:
+        - lang: 'Shell'
+          source: |
+            curl -X GET https://www.targetvalidation.org/api/latest/public/utils/version
   /platform/public/utils/stats:
     get:
+      summary: Get statistics about the current data release
       operationId: getDataStats
       tags:
         - public
         - utils
       description: |
-        Get stats about available data.
+        Returns the number of associations and evidences, divided by datasource.
       responses:
         200:
           description: Successful response
+      x-code-samples:
+        - lang: 'Python'
+          source: |
+            import requests
+            r = requests.get('https://www.targetvalidation.com/api/latest/public/stats')
+            assert r.status_code == 200
+            assert r.headers['content-type'] == 'application/json'
+            print(r.json())

--- a/openapi.template.yaml
+++ b/openapi.template.yaml
@@ -268,6 +268,11 @@ paths:
       responses:
         200:
           description: Successful response
+      x-code-samples:
+        - lang: 'httpie'
+          source: |
+            http https://www.targetvalidation.org/api/latest/public/evidence/filter target==ENSG00000167207 disease==EFO_0003767 datastructure==simple
+
     post:
       summary: Batch filter available evidence
       operationId: postEvidenceFilter
@@ -464,6 +469,10 @@ paths:
           #     properties:
           #       id:
           #         type: string
+      x-code-samples:
+        - lang: 'httpie'
+          source: |
+            http https://www.targetvalidation.org/api/latest/public/association/filter target==ENSG00000167207 disease==EFO_0003767
     post:
       summary: Batch query available associations
       operationId: postAssociationFilter
@@ -760,6 +769,19 @@ paths:
       responses:
         200:
           description: Successful response
+      x-code-samples:
+        - lang: 'httpie'
+          source: |
+            http https://api.opentargets.io/api/latest/public/search q==NOD2 size==1 filter==target
+        - lang: 'Python'
+          source: |
+            import requests
+            from pprint import pprint
+            r = requests.get('https://www.targetvalidation.org/api/latest/public/search',
+                            params={"q":"NOD2","size":1})
+            pprint(r.json())
+
+
   /platform/private/quicksearch:
     get:
       summary: Search most relevant results

--- a/openapi.template.yaml
+++ b/openapi.template.yaml
@@ -23,7 +23,7 @@ info:
     Fair usage is enforced with limits to the api calls. Consistently exceeding the fair usage limits will trigger at
     least a 24 hour ban.
 tags:
-  - name: filters
+  - name: filter
     # open: true
     description: Methods to filter the available evidence.
   - name: retrieve
@@ -55,6 +55,7 @@ x-tagGroups:
       - utils
       - private
   - name: All
+    tags:
       - public
       - private
 consumes:

--- a/openapi.template.yaml
+++ b/openapi.template.yaml
@@ -60,12 +60,23 @@ paths:
       operationId: getApiDocs
       tags:
         - private
-      description: Get api-description.md for the API
+      description: Access api docs as served by Redoc
       produces:
       - "application/json"
       responses:
         200:
-          description: "Markdown API documentation file"
+          description: "Redoc API documentation file"
+  /platform/docs/swagger-ui:
+    get:
+      operationId: getApiSwaggerUI
+      tags:
+        - private
+      description: Interactive API docs using swagger-ui
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "Swagger-UI API documentation file"
   /platform/public/evidence:
     get:
       operationId: getEvidenceById


### PR DESCRIPTION
merging will allow to browse to swagger-ui at `/v3/platform/docs/swagger-ui/` 

also reworked the tag groups and the summary fields so that the redoc documentation is more clear for the casual reader:

![image](https://user-images.githubusercontent.com/112610/40333315-cb5fdaf4-5d4f-11e8-9bfc-f6f7bf12c9a2.png)
 
instead of the current:

![image](https://user-images.githubusercontent.com/112610/40333549-f408fade-5d50-11e8-8f11-8a55db57fd48.png)
