### PR TITLE
update uwsgi version to one that works

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ six==1.9.0
 SQLAlchemy==0.9.8
 ujson==1.33
 urllib3==1.10.2
-uWSGI==2.0.13.1
+uWSGI==2.0.17.1
 Werkzeug==0.10.1
 Yapsy==1.10.423
 numpy==1.9.2


### PR DESCRIPTION
The previous uWSGI version no longer compiles in Circle CI - this one does work. Solves issue https://github.com/opentargets/platform/issues/14 .