### PR TITLE
adding empty nginx config file that can be overwritten at runtime

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,6 +38,7 @@ COPY docker/nginx.conf /etc/nginx/
 COPY docker/nginx-rest-api.conf /etc/nginx/sites-enabled/
 COPY docker/nginx-proxy.conf /etc/nginx/sites-enabled/
 COPY docker/nginx-servers.conf /etc/nginx/sites-enabled/
+COPY docker/nginx-custom.conf /etc/nginx/sites-enabled/
 COPY docker/selfsigned.server.crt /etc/ssl/nginx/server.crt
 COPY docker/selfsigned.server.key /etc/ssl/nginx/server.key
 

--- a/docker/nginx-custom.conf
+++ b/docker/nginx-custom.conf
@@ -1,0 +1,4 @@
+# extra configuration file for easily adding extra custom server {} related
+# options to nginx at runtime (like custom sites to proxy).
+# Just replace this empy file by your custom file by ovewriting
+# the /etc/nginx/sites-enabled/nginx-custom.conf file, e.g. with a docker volume.

--- a/docker/nginx-servers.conf
+++ b/docker/nginx-servers.conf
@@ -37,6 +37,7 @@ server {
     location / { try_files $uri $uri/ @rest_api; }
     include /etc/nginx/sites-enabled/nginx-proxy.conf;
     include /etc/nginx/sites-enabled/nginx-rest-api.conf;
+    include /etc/nginx/sites-enabled/nginx-custom.conf;
 }
 
 
@@ -68,4 +69,5 @@ server {
     }
     include /etc/nginx/sites-enabled/nginx-proxy.conf;
     include /etc/nginx/sites-enabled/nginx-rest-api.conf;
+    include /etc/nginx/sites-enabled/nginx-custom.conf;
 }


### PR DESCRIPTION
Adding extra configuration file for easily adding extra custom server {} related options to nginx at runtime (like custom sites to proxy).

E.g. when using docker, this feature makes it easy to add custom configuration as a volume overwriting  the empty /etc/nginx/sites-enabled/nginx-custom.conf file.