### PR TITLE
Fixed endpoint stats

### DIFF
--- a/app/common/response_templates.py
+++ b/app/common/response_templates.py
@@ -247,10 +247,9 @@ class DataStats(object):
                 datasources[ds_bucket['key']]={'total':ds_bucket['doc_count']}
                 datatypes[bucket['key']]['datasources']=datasources
 
-        self.evidencestrings = dict(total = res['hits']['total']['value'],
-                                    datatypes= datatypes)
+        self.evidencestrings = dict(datatypes= datatypes)
 
-    def add_associations(self, res, known_datatypes):
+    def add_associations(self, res, index_association_stats, known_datatypes):
         datatypes = {}
         for bucket in res['aggregations']['data']['buckets']:
             datatypes[bucket['key']]={'total':bucket['doc_count']}
@@ -264,7 +263,7 @@ class DataStats(object):
                     pass
 
 
-        self.associations = dict(total = res['hits']['total']['value'],
+        self.associations = dict(total = index_association_stats,
                                  datatypes= datatypes)
 
     def add_key_value(self, key, value):


### PR DESCRIPTION
The migration to ElasticSearch 7.2 requires different queries to retrieve the stats data.
